### PR TITLE
Add initial stab at grab_streams.sh

### DIFF
--- a/grab_streams.sh
+++ b/grab_streams.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+function cmd_exists() {
+  type "$1" > /dev/null 2>&1
+}
+
+function main() {
+  streams_endpoint=https://api.twitch.tv/kraken/streams\?game\=PLAYERUNKNOWN\'\S+BATTLEGROUNDS
+
+  if [[ -z "$client_id" ]]; then
+    echo "Need to set environment variable client_id!"
+    exit 1
+  fi
+
+  if [[ ! cmd_exists jq ]]; then
+    echo "Need to install jq (ex: apt-get install jq)"
+    exit 1
+  fi
+
+  curl -s -H "Client-ID: $client_id" \
+       $streams_endpoint             \
+       | jq '.' > streams.txt
+}
+
+main "$@"


### PR DESCRIPTION
This script gives the ability to pull a list of streams by game. Right
now it pulls ALL streams, we will soon need to filter. It relies on:

  * environment variable client_id being set
  * jq being installed

There are checks for both of these conditions and the script will exit
non-zero if either of them fail.

Signed-off-by: Cullen Taylor <cullentaylor@outlook.com>